### PR TITLE
remove factor of 1e-6 in core_shift

### DIFF
--- a/src/gipaw_setup.f90
+++ b/src/gipaw_setup.f90
@@ -348,7 +348,7 @@ SUBROUTINE gipaw_setup_integrals
     enddo
     deallocate ( work )
 
-    nmr_shift_core(nt) = nmr_shift_core(nt) * 17.75045395 * 1e-6
+    nmr_shift_core(nt) = nmr_shift_core(nt) * 17.75045395
   enddo
 
 


### PR DESCRIPTION
The integration tests were not passing on main because the core shift was wrong. Somehow the factor of 1e-6 is not needed. and the core shift is already in ppm. The integration test basically just compare the standard out of a simulation with v 7.2 with the current one. The two values don't agree.

@SFioccola Do you think the conversion factor can safely be removed here?